### PR TITLE
Update blue-green-deployment.yml

### DIFF
--- a/.github/workflows/blue-green-deployment.yml
+++ b/.github/workflows/blue-green-deployment.yml
@@ -5,9 +5,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
 
     steps:
       - name: Checkout repository
@@ -17,49 +21,14 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 12
-
-      - name: Deploy App to GitHub Pages
-        env:
-          ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
-          GH_PAGES: true
+      
+      - name: Install and Build
         run: |
-          # Determine the current environment branch
-          current_branch=$(curl -L "Accept: application/vnd.github+json" -H "Authorization: Bearer $ACTIONS_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/${{ github.repository }}/pages | jq -r .source.branch)
-          
-          # Determine the target environment branch
-          if [ "$current_branch" = "gh-pages-blue" ]; then
-            target_branch="gh-pages-green"
-          else
-            target_branch="gh-pages-blue"
-          fi
-
-          # Report back
-          echo The static site is current deployed to $current_branch.
-          echo Targeting $target_branch for the deployment.
-
-          # Configure the user and email for the commit
-          git config user.name "github-actions"
-          git config user.email "github-actions@users.noreply.github.com"
-
-          # Delete the current target branch
-          request_status=$(curl -s -o /dev/null -X DELETE -H "Authorization: token $ACTIONS_TOKEN" https://api.github.com/repos/${{ github.repository }}/git/refs/heads/$target_branch)
-
-          # Perform a clean install of dependencies
           npm ci
-
-          # Build the application for production
           npm run build
-
-          # Commit the code and push to the target branch
-          git add .
-          git commit -m 'Deploy the GitHub Pages site to the $target_branch branch'
-          git subtree push --prefix dist origin $target_branch
-
-          # Set GitHub Pages source
-          if [ "$current_branch" = "null" ]; then
-            # If $current_branch is empty/null, perform a POST request to create GitHub Pages
-            curl -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $ACTIONS_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/${{ github.repository }}/pages -d '{"source":{"branch": "'"$target_branch"'","path":"/"}}'
-          else
-            # If $current_branch is not empty, perform a PUT request to update GitHub Pages
-            curl -L -X PUT -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $ACTIONS_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/${{ github.repository }}/pages -d '{"source":{"branch": "'"$target_branch"'","path":"/"}}'
-          fi
+          
+      - name: Deploy App to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4
+        with:
+          branch: gh-pages
+          folder: dist


### PR DESCRIPTION
Now uses only a single gh-pages branch for deployment by making use of [`concurrency`](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency) workflow parameter and [github-pages-deploy-action](https://github.com/marketplace/actions/deploy-to-github-pages).

You might need to change the repository settings for deployment to ensure Pages is pointing to the correct branch.  This should allow for more flexibility with future updates to the project.